### PR TITLE
Add ability to configure custom category icons (platform-bound)

### DIFF
--- a/fabric/src/main/java/stonks/fabric/PlatformConfig.java
+++ b/fabric/src/main/java/stonks/fabric/PlatformConfig.java
@@ -21,7 +21,17 @@
  */
 package stonks.fabric;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
 import nahara.common.configurations.Config;
+import net.minecraft.command.argument.ItemStackArgumentType;
+import net.minecraft.item.Item;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandManager;
 import stonks.fabric.menu.product.input.OfferCustomPriceInput;
 
 /**
@@ -33,14 +43,30 @@ public class PlatformConfig {
 	public int decimals = 2;
 	public double tax = 0d;
 	public double topOfferPriceDelta = 0.1d;
+	public final Map<String, Item> categoryIcons = new HashMap<>();
 
-	public void from(Config config) {
+	public void fromConfig(MinecraftServer server, Config config) {
 		config.firstChild("decimals").flatMap(v -> v.getValue(Integer::parseInt))
 			.ifPresent(v -> decimals = v);
 		config.firstChild("tax").flatMap(v -> v.getValue(Double::parseDouble))
 			.ifPresent(v -> tax = v);
 		config.firstChild("topOfferPriceDelta").flatMap(v -> v.getValue(Double::parseDouble))
 			.ifPresent(v -> topOfferPriceDelta = v);
+
+		config.children("categoryIcon").forEach(v -> {
+			var splits = v.getValue().map(u -> u.split(" ", 2));
+			if (splits.isEmpty()) return;
+			if (splits.get().length < 2) return;
+
+			try {
+				var id = splits.get()[0];
+				var registry = CommandManager.createRegistryAccess(server.getRegistryManager());
+				var parsed = ItemStackArgumentType.itemStack(registry).parse(new StringReader(splits.get()[1]));
+				categoryIcons.put(id, parsed.getItem());
+			} catch (CommandSyntaxException e) {
+				StonksFabric.LOGGER.warn("PlatformConfig: Failed to parse {}", splits.get()[1]);
+			}
+		});
 	}
 
 	// Processing methods

--- a/fabric/src/main/java/stonks/fabric/StonksFabric.java
+++ b/fabric/src/main/java/stonks/fabric/StonksFabric.java
@@ -118,7 +118,7 @@ public class StonksFabric {
 
 			if (child.getKey().equals("platformConfig") || child.getKey().equals("fabric.platformConfig")) {
 				LOGGER.info("Found platform configurations!");
-				config.from(child);
+				config.fromConfig(server, child);
 			}
 		}
 

--- a/fabric/src/main/java/stonks/fabric/menu/MarketMainMenu.java
+++ b/fabric/src/main/java/stonks/fabric/menu/MarketMainMenu.java
@@ -157,6 +157,8 @@ public class MarketMainMenu extends StackedMenu {
 	}
 
 	private void placeCategories(List<Category> categories) {
+		var categoryIcons = StonksFabric.getPlatform(getPlayer()).getPlatformConfig().categoryIcons;
+
 		for (int i = 0; i < getHeight() - 1; i++) {
 			var currentCategoryIndex = categoriesPage * CATEGORIES_PER_PAGE + i;
 			var slot = (i + 1) * getWidth();
@@ -165,7 +167,7 @@ public class MarketMainMenu extends StackedMenu {
 				var category = categories.get(currentCategoryIndex);
 				var selected = currentCategoryIndex == selectedCategoryIndex;
 
-				var a = new GuiElementBuilder(Items.PAPER)
+				var a = new GuiElementBuilder(categoryIcons.getOrDefault(category.getCategoryId(), Items.PAPER))
 					.setName(Text.literal(category.getCategoryName())
 						.styled(s -> s.withColor(Formatting.AQUA)))
 					.addLoreLine(selected

--- a/fabric/src/main/resources/default-config
+++ b/fabric/src/main/resources/default-config
@@ -19,6 +19,11 @@ platformConfig
     // in offer price setup menu.
     topOfferPriceDelta 0.1
 
+    // Category icons
+    // If you don't specify icons here, it will defaults to minecraft:paper
+    categoryIcon foods minecraft:carrot
+    categoryIcon specials minecraft:diamond
+
 // Service
 // You can only have 1 active service for each server
 useService stonks.fabric.service.IntegratedStonksService


### PR DESCRIPTION
Another approach is to let platforms handles categories while services only reports product IDs.