### PR TITLE
Fix null display stack on products with unknown construction data

### DIFF
--- a/fabric/src/main/java/stonks/fabric/menu/product/OfferAmountConfigureMenu.java
+++ b/fabric/src/main/java/stonks/fabric/menu/product/OfferAmountConfigureMenu.java
@@ -90,7 +90,7 @@ public class OfferAmountConfigureMenu extends StackedMenu {
 	private GuiElementBuilder createOfferSelectButton(int amount, Item icon) {
 		// Only for selling
 		var fillAll = amount == -1;
-		var currentUnits = StonksFabric.getPlatform(getPlayer()).getStonksAdapter().getUnits(player, product).or(0);
+		var currentUnits = StonksFabric.getPlatform(getPlayer()).getStonksAdapter().getUnits(player, product);
 		if (fillAll) amount = currentUnits;
 		var disabled = offerType == OfferType.SELL && (amount == 0 || currentUnits < amount);
 		var amount2 = amount;

--- a/fabric/src/main/java/stonks/fabric/menu/product/OfferAmountConfigureMenu.java
+++ b/fabric/src/main/java/stonks/fabric/menu/product/OfferAmountConfigureMenu.java
@@ -57,7 +57,8 @@ public class OfferAmountConfigureMenu extends StackedMenu {
 		case SELL -> new Item[] { Items.GOLD_NUGGET, Items.GOLD_INGOT, Items.GOLD_BLOCK };
 		};
 
-		setSlot(7, StonksFabric.getPlatform(getPlayer()).getStonksAdapter().createDisplayStack(product));
+		var displayStack = StonksFabric.getPlatform(getPlayer()).getStonksAdapter().createDisplayStack(product);
+		if (displayStack != null) setSlot(7, displayStack);
 
 		setSlot(19, createOfferSelectButton(64, icons[0]));
 		setSlot(20, createOfferSelectButton(256, icons[1]));
@@ -89,7 +90,7 @@ public class OfferAmountConfigureMenu extends StackedMenu {
 	private GuiElementBuilder createOfferSelectButton(int amount, Item icon) {
 		// Only for selling
 		var fillAll = amount == -1;
-		var currentUnits = StonksFabric.getPlatform(getPlayer()).getStonksAdapter().getUnits(player, product);
+		var currentUnits = StonksFabric.getPlatform(getPlayer()).getStonksAdapter().getUnits(player, product).or(0);
 		if (fillAll) amount = currentUnits;
 		var disabled = offerType == OfferType.SELL && (amount == 0 || currentUnits < amount);
 		var amount2 = amount;

--- a/fabric/src/main/java/stonks/fabric/menu/product/OfferPriceConfigureMenu.java
+++ b/fabric/src/main/java/stonks/fabric/menu/product/OfferPriceConfigureMenu.java
@@ -55,9 +55,13 @@ public class OfferPriceConfigureMenu extends StackedMenu {
 			? Translations.Menus.CreateOffer.Title$Buy(product)
 			: Translations.Menus.CreateOffer.Title$Sell(product));
 
-		setSlot(7, GuiElementBuilder.from(StonksFabric.getPlatform(getPlayer())
+		var displayStack = StonksFabric.getPlatform(getPlayer())
 			.getStonksAdapter()
-			.createDisplayStack(product))
+			.createDisplayStack(product);
+		var builder = displayStack != null
+			? GuiElementBuilder.from(displayStack)
+			: new GuiElementBuilder(Items.BARRIER);
+		setSlot(7, builder
 			.setCount(Math.min(Math.max(amount / 64, 1), 64))
 			.setName(Text.literal(amount + "x " + product.getProductName()) // TODO
 				.styled(s -> s.withColor(Formatting.AQUA)))


### PR DESCRIPTION
When the construction data on product is not supported by any adapters, clicking on that product can cause NPE.