### PR TITLE
Stonks Server (standalone application + remote service)

### DIFF
--- a/core/src/main/java/stonks/core/net/ClientConnection.java
+++ b/core/src/main/java/stonks/core/net/ClientConnection.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.net;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+import stonks.core.net.listener.NewConnectionsListener;
+
+public class ClientConnection extends Connection {
+	private SocketChannel client;
+	private NewConnectionsListener handler;
+
+	public ClientConnection(SocketChannel client, NewConnectionsListener handler) throws IOException {
+		this.client = client;
+		this.handler = handler;
+	}
+
+	public void startOnCurrentThread() throws IOException {
+		while (!client.finishConnect()) { if (isCloseNeeded()) return; }
+		handler.onNewConnection(this);
+
+		do {
+			handleRead(client);
+			handleWrite(client);
+
+			try {
+				Thread.sleep(1);
+			} catch (InterruptedException e) {
+				// Interrupted while sleeping
+				break;
+			}
+
+			if (Thread.currentThread().isInterrupted()) break;
+		} while (!isCloseNeeded());
+
+		setClosed(true);
+		emitClose();
+		client.close();
+	}
+
+	public Thread createThread() {
+		var thread = new Thread(() -> {
+			try {
+				startOnCurrentThread();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		});
+		thread.setName("Client Networking Thread");
+		return thread;
+	}
+}

--- a/core/src/main/java/stonks/core/net/Connection.java
+++ b/core/src/main/java/stonks/core/net/Connection.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.net;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import stonks.core.net.listener.ConnectionClosedListener;
+import stonks.core.net.listener.IncomingRawPacketsListener;
+
+public class Connection {
+	private Queue<ByteBuffer> outgoingQueue = new ConcurrentLinkedQueue<>();
+	private List<IncomingRawPacketsListener> rawPacketsListeners = new ArrayList<>();
+	private List<ConnectionClosedListener> closeListeners = new ArrayList<>();
+
+	// Packet specification
+	// 2 bytes: Packet length (always uncompressed). Maximum length of 32767.
+	// [length] bytes: Packet content
+	private ByteBuffer header;
+	private ByteBuffer content;
+	private int contentLength = -1;
+	private boolean closeNeeded = false, isClosed = false;
+
+	protected Connection() {
+		header = ByteBuffer.allocateDirect(2);
+		content = ByteBuffer.allocateDirect(32767);
+	}
+
+	protected void handleRead(SocketChannel socket) throws IOException {
+		if (!socket.isOpen()) {
+			requestClose();
+			return;
+		}
+
+		if (isCloseNeeded()) return;
+
+		if (contentLength == -1) {
+			var byteRead = socket.read(header);
+			if (byteRead == -1) {
+				requestClose();
+				return;
+			}
+
+			if (!header.hasRemaining()) {
+				header.flip();
+				var length = header.getShort();
+				if (length < 0) {
+					// Likely over 32767, because Java doesn't have unsigned short
+					requestClose();
+					return;
+				}
+
+				content.clear();
+				content.limit(contentLength = length);
+
+				if (length == 0) {
+					content.flip();
+					emitIncomingRawPacket(content);
+					header.clear();
+					contentLength = -1;
+					if (isCloseNeeded()) return;
+				}
+			} else {
+				// We might have 1 or 2 more bytes to read
+				return;
+			}
+		} else {
+			var byteRead = socket.read(content);
+			if (byteRead == -1) {
+				requestClose();
+				return;
+			}
+
+			if (!content.hasRemaining()) {
+				content.flip();
+				emitIncomingRawPacket(content);
+
+				// Ready to read next packet
+				header.clear();
+				contentLength = -1;
+				if (isCloseNeeded()) return;
+			}
+		}
+	}
+
+	protected void handleWrite(SocketChannel socket) throws IOException {
+		while (!outgoingQueue.isEmpty()) {
+			var content = outgoingQueue.poll();
+			header.clear();
+			header.putShort((short) content.limit());
+			header.flip();
+			socket.write(header);
+
+			// Sometimes you forgot to flip the buffer
+			// Yep, a single method had drove me insane for 2 hours - nahkd123
+			if (content.position() != 0) content.flip();
+			socket.write(content);
+		}
+
+		// Prevent client from reading itself
+		header.clear();
+	}
+
+	protected boolean isCloseNeeded() { return closeNeeded; }
+
+	/**
+	 * <p>
+	 * Listen for incoming raw packets.
+	 * </p>
+	 * 
+	 * @param listener
+	 */
+	public void listenRawPackets(IncomingRawPacketsListener listener) {
+		rawPacketsListeners.add(listener);
+	}
+
+	/**
+	 * <p>
+	 * Listen for close events.
+	 * </p>
+	 * 
+	 * @param listener
+	 */
+	public void listenClose(ConnectionClosedListener listener) {
+		closeListeners.add(listener);
+	}
+
+	protected void emitIncomingRawPacket(ByteBuffer raw) {
+		for (var l : rawPacketsListeners) l.onIncomingRawPacket(this, raw);
+	}
+
+	protected void emitClose() {
+		for (var l : closeListeners) l.onClosed(this);
+	}
+
+	/**
+	 * <p>
+	 * Request {@link ServerHandler} to close this connection.
+	 * </p>
+	 */
+	public void requestClose() {
+		closeNeeded = true;
+	}
+
+	public boolean isClosed() { return isClosed; }
+
+	protected void setClosed(boolean isClosed) { this.isClosed = isClosed; }
+
+	public void sendRawPacket(ByteBuffer buffer) {
+		outgoingQueue.add(buffer);
+	}
+
+	protected void closeAttachment() {
+		// Attempt to dereference as much buffers as possible
+		// I know this is not needed, but like, who knows, maybe selection key still
+		// holds reference to this attachment object.
+		header = null;
+		content = null;
+	}
+}

--- a/core/src/main/java/stonks/core/net/Connection.java
+++ b/core/src/main/java/stonks/core/net/Connection.java
@@ -70,7 +70,6 @@ public class Connection {
 			if (!header.hasRemaining()) {
 				header.flip();
 				var length = header.getInt();
-				System.out.println(length);
 				if (length < 0 || length > MAX_PACKET_LENGTH) {
 					requestClose();
 					return;

--- a/core/src/main/java/stonks/core/net/ServerHandler.java
+++ b/core/src/main/java/stonks/core/net/ServerHandler.java
@@ -81,6 +81,8 @@ public class ServerHandler {
 				conn.closeAttachment();
 			}
 		}
+
+		selector = null;
 	}
 
 	public Thread createThread() {
@@ -94,6 +96,8 @@ public class ServerHandler {
 		thread.setName("Server Networking Thread");
 		return thread;
 	}
+
+	public Selector getSelector() { return selector; }
 
 	protected void selectLoop() throws IOException {
 		selector.select();

--- a/core/src/main/java/stonks/core/net/ServerHandler.java
+++ b/core/src/main/java/stonks/core/net/ServerHandler.java
@@ -68,7 +68,19 @@ public class ServerHandler {
 		server.register(selector, SelectionKey.OP_ACCEPT);
 
 		while (isRunning) selectLoop();
+
 		// TODO logger or emit events
+		for (var key : selector.keys()) {
+			var attachment = key.attachment();
+
+			if (attachment != null && attachment instanceof Connection conn) {
+				// We close all connections
+				conn.setClosed(true);
+				conn.emitClose();
+				close(key, conn);
+				conn.closeAttachment();
+			}
+		}
 	}
 
 	public Thread createThread() {

--- a/core/src/main/java/stonks/core/net/ServerHandler.java
+++ b/core/src/main/java/stonks/core/net/ServerHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.net;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import stonks.core.net.listener.NewConnectionsListener;
+
+/**
+ * <p>
+ * Non-blocking IO server socket handler.
+ * </p>
+ */
+public class ServerHandler {
+	private ServerSocketChannel server;
+	private NewConnectionsListener listener;
+	private boolean isRunning = false;
+	private Selector selector;
+
+	public ServerHandler(ServerSocketChannel server, NewConnectionsListener handler) throws IOException {
+		this.server = server;
+		this.listener = handler;
+		this.server.configureBlocking(false);
+	}
+
+	public ServerSocketChannel getServer() { return server; }
+
+	/**
+	 * <p>
+	 * Start the server handler on current thread.
+	 * </p>
+	 * <p>
+	 * This will block the current thread until another thread called the stop
+	 * method.
+	 * </p>
+	 * <p>
+	 * If the server is already running, this will do nothing.
+	 * </p>
+	 */
+	public void startOnCurrentThread() throws IOException {
+		if (isRunning) return;
+		isRunning = true;
+
+		selector = Selector.open();
+		server.register(selector, SelectionKey.OP_ACCEPT);
+
+		while (isRunning) selectLoop();
+		// TODO logger or emit events
+	}
+
+	public Thread createThread() {
+		var thread = new Thread(() -> {
+			try {
+				startOnCurrentThread();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		});
+		thread.setName("Server Networking Thread");
+		return thread;
+	}
+
+	protected void selectLoop() throws IOException {
+		selector.select();
+		var selectionKeys = selector.selectedKeys();
+		var selectionKeysIter = selectionKeys.iterator();
+
+		while (selectionKeysIter.hasNext()) {
+			var key = selectionKeysIter.next();
+			selectionKeysIter.remove();
+
+			if (key.isAcceptable()) accept(key);
+
+			if (key.isReadable()) {
+				var attachment = (Connection) key.attachment();
+				attachment.handleRead((SocketChannel) key.channel());
+
+				if (attachment.isCloseNeeded()) {
+					close(key, attachment);
+					continue;
+				}
+			}
+
+			if (key.isWritable()) {
+				var attachment = (Connection) key.attachment();
+				attachment.handleWrite((SocketChannel) key.channel());
+
+				if (attachment.isCloseNeeded()) {
+					close(key, attachment);
+					continue;
+				}
+			}
+		}
+	}
+
+	protected void accept(SelectionKey key) throws IOException {
+		var keyChannel = (ServerSocketChannel) key.channel();
+		var socket = keyChannel.accept();
+		socket.configureBlocking(false);
+
+		var attachment = new Connection();
+		socket.register(selector, SelectionKey.OP_READ | SelectionKey.OP_WRITE, attachment);
+		listener.onNewConnection(attachment);
+	}
+
+	protected void close(SelectionKey key, Connection attachment) throws IOException {
+		attachment.closeAttachment();
+		attachment.setClosed(true);
+		attachment.emitClose();
+		key.channel().close();
+	}
+
+	public void stop() {
+		isRunning = false;
+		selector.wakeup();
+	}
+}

--- a/core/src/main/java/stonks/core/net/listener/ConnectionClosedListener.java
+++ b/core/src/main/java/stonks/core/net/listener/ConnectionClosedListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.net.listener;
+
+import stonks.core.net.Connection;
+
+@FunctionalInterface
+public interface ConnectionClosedListener {
+	public void onClosed(Connection connection);
+}

--- a/core/src/main/java/stonks/core/net/listener/IncomingRawPacketsListener.java
+++ b/core/src/main/java/stonks/core/net/listener/IncomingRawPacketsListener.java
@@ -1,0 +1,10 @@
+package stonks.core.net.listener;
+
+import java.nio.ByteBuffer;
+
+import stonks.core.net.Connection;
+
+@FunctionalInterface
+public interface IncomingRawPacketsListener {
+	public void onIncomingRawPacket(Connection connection, ByteBuffer raw);
+}

--- a/core/src/main/java/stonks/core/net/listener/IncomingRawPacketsListener.java
+++ b/core/src/main/java/stonks/core/net/listener/IncomingRawPacketsListener.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package stonks.core.net.listener;
 
 import java.nio.ByteBuffer;

--- a/core/src/main/java/stonks/core/net/listener/NewConnectionsListener.java
+++ b/core/src/main/java/stonks/core/net/listener/NewConnectionsListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.net.listener;
+
+import stonks.core.net.Connection;
+
+@FunctionalInterface
+public interface NewConnectionsListener {
+	public void onNewConnection(Connection connection);
+}

--- a/core/src/main/java/stonks/core/service/StonksService.java
+++ b/core/src/main/java/stonks/core/service/StonksService.java
@@ -32,7 +32,25 @@ import stonks.core.market.OfferType;
 import stonks.core.market.ProductMarketOverview;
 import stonks.core.product.Category;
 import stonks.core.product.Product;
+import stonks.core.service.memory.StonksMemoryService;
+import stonks.core.service.remote.StonksRemoteService;
 
+/**
+ * <p>
+ * The interface for accessing Stonks service.
+ * </p>
+ * <p>
+ * Each method that returns {@link Task} is a service call, which will be
+ * resolved in the service thread. For {@link StonksMemoryService}, it will be
+ * resolved in the thread that called the method. For
+ * {@link StonksRemoteService}, it will be resolved in networking thread.
+ * </p>
+ * <p>
+ * Method {@link #subscribeToOfferFilledEvents(Consumer)} will call your
+ * callback functions in service thread. That means your callback will be called
+ * in networking thread if you are using {@link StonksRemoteService}.
+ * </p>
+ */
 public interface StonksService {
 	/**
 	 * <p>

--- a/core/src/main/java/stonks/core/service/remote/RemoteServiceException.java
+++ b/core/src/main/java/stonks/core/service/remote/RemoteServiceException.java
@@ -23,7 +23,9 @@ package stonks.core.service.remote;
 
 import java.io.Serial;
 
-public class RemoteServiceException extends RuntimeException {
+import stonks.core.service.ServiceException;
+
+public class RemoteServiceException extends ServiceException {
 	@Serial
 	private static final long serialVersionUID = -3996422054534353037L;
 

--- a/core/src/main/java/stonks/core/service/remote/RemoteServiceException.java
+++ b/core/src/main/java/stonks/core/service/remote/RemoteServiceException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote;
+
+import java.io.Serial;
+
+public class RemoteServiceException extends RuntimeException {
+	@Serial
+	private static final long serialVersionUID = -3996422054534353037L;
+
+	public RemoteServiceException(String message) {
+		super(message);
+	}
+
+	public RemoteServiceException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/StonksRemoteServer.java
+++ b/core/src/main/java/stonks/core/service/remote/StonksRemoteServer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote;
+
+import java.io.IOException;
+import java.nio.channels.ServerSocketChannel;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+
+import nahara.common.tasks.Task;
+import nahara.common.tasks.TaskResult;
+import stonks.core.net.Connection;
+import stonks.core.net.ServerHandler;
+import stonks.core.product.Category;
+import stonks.core.product.Product;
+import stonks.core.service.StonksService;
+import stonks.core.service.remote.message.MessageC2SQueryProducts;
+import stonks.core.service.remote.message.MessageS2CQueryProductsPartial;
+import stonks.core.service.remote.message.MessagesHandler;
+
+public class StonksRemoteServer {
+	private StonksService service;
+	private ServerHandler server;
+	private MessagesHandler messagesHandler;
+
+	private static record WaitingTask(Task<?> task, Consumer<TaskResult<?>> onFinished) {
+	}
+
+	private Queue<WaitingTask> waiting = new ConcurrentLinkedQueue<>();
+
+	@SuppressWarnings("unchecked")
+	public StonksRemoteServer(StonksService service, ServerSocketChannel channel) throws IOException {
+		this.service = service;
+		this.server = new ServerHandler(channel, this::onNewConnection) {
+			@Override
+			protected void selectLoop() throws IOException {
+				StonksRemoteServer.this.beforeSelectLoop();
+				super.selectLoop();
+			}
+		};
+
+		messagesHandler = new MessagesHandler();
+		messagesHandler.registerDeserializer(MessageC2SQueryProducts.ID, MessageC2SQueryProducts::new);
+		messagesHandler.listenForMessage(MessageC2SQueryProducts.class, msg -> {
+			waiting.add(new WaitingTask(service.queryAllCategories(), result -> {
+				if (!result.isSuccess()) {
+					msg.connection()
+						.sendRawPacket(new MessageS2CQueryProductsPartial("Query failed").createRawPacket());
+					result.getFailure().printStackTrace();
+					return;
+				}
+
+				var list = (List<Category>) result.getSuccess();
+				Product last = null;
+
+				for (var category : list) {
+					for (var product : category.getProducts()) {
+						if (last != null) msg.connection()
+							.sendRawPacket(new MessageS2CQueryProductsPartial(last, false).createRawPacket());
+						last = product;
+						continue;
+					}
+				}
+
+				if (last == null) {
+					msg.connection()
+						.sendRawPacket(new MessageS2CQueryProductsPartial("", "", "", "", "", true).createRawPacket());
+				} else {
+					msg.connection()
+						.sendRawPacket(new MessageS2CQueryProductsPartial(last, true).createRawPacket());
+				}
+			}));
+		});
+	}
+
+	public StonksService getService() { return service; }
+
+	public ServerHandler getServer() { return server; }
+
+	public MessagesHandler getMessagesHandler() { return messagesHandler; }
+
+	protected void onNewConnection(Connection connection) {
+		// TODO log new connection to console
+		messagesHandler.handleConnection(connection);
+	}
+
+	protected void beforeSelectLoop() {
+		var iter = waiting.iterator();
+		while (iter.hasNext()) {
+			var waiting = iter.next();
+			var now = waiting.task.get();
+			if (now.isEmpty()) continue;
+			iter.remove();
+			waiting.onFinished().accept(now.get());
+		}
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/StonksRemoteService.java
+++ b/core/src/main/java/stonks/core/service/remote/StonksRemoteService.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import nahara.common.tasks.ManualTask;
+import nahara.common.tasks.Task;
+import stonks.core.exec.InstantOfferExecuteResult;
+import stonks.core.market.Offer;
+import stonks.core.market.OfferType;
+import stonks.core.market.ProductMarketOverview;
+import stonks.core.net.Connection;
+import stonks.core.product.Category;
+import stonks.core.product.Product;
+import stonks.core.service.StonksService;
+import stonks.core.service.memory.MemoryCategory;
+import stonks.core.service.memory.MemoryProduct;
+import stonks.core.service.remote.message.MessageC2SQueryProducts;
+import stonks.core.service.remote.message.MessageS2CQueryProductsPartial;
+import stonks.core.service.remote.message.MessagesHandler;
+
+/**
+ * <p>
+ * An interface to interact with remote service.
+ * </p>
+ * <p>
+ * Remote service allows you to share Stonks market data to multiple front-ends.
+ * You can use this to sync between 2 game servers or just use this if your game
+ * server crash a lot (to avoid losing data).
+ * </p>
+ * <p>
+ * Note that tasks will be resolved in networking thread. If you want to make
+ * some changes that requires the game server thread, you have to synchronize by
+ * either scheduling on next server tick or use
+ * {@code MinecraftServer#execute()}.
+ * </p>
+ * <p>
+ * <b>Caching</b>: {@link StonksRemoteService} caches return value of
+ * {@link #queryAllCategories()}, so if you just added something from remote
+ * service, you'll have to restart your game server OR clear the cache with
+ * {@link #clearRemoteCache()}
+ * </p>
+ */
+public class StonksRemoteService implements StonksService {
+	private List<Category> cachedCategories;
+	private List<Category> scanningCategories;
+	private Connection connection;
+	private MessagesHandler messagesHandler;
+
+	private ManualTask<List<Category>> categoriesQueryTask;
+
+	public StonksRemoteService(Connection connection) {
+		this.connection = connection;
+
+		// TODO
+		messagesHandler = new MessagesHandler();
+		messagesHandler.registerDeserializer(MessageS2CQueryProductsPartial.ID, MessageS2CQueryProductsPartial::new);
+		messagesHandler.listenForMessage(MessageS2CQueryProductsPartial.class, msg -> {
+			if (msg.message().getErrorMessage().isPresent()) {
+				// TODO use different exception
+				categoriesQueryTask.resolveFailure(new RuntimeException(msg.message().getErrorMessage().get()));
+				scanningCategories = null;
+				return;
+			}
+
+			// cachedCategories = msg.message().getCategories();
+			// categoriesQueryTask.resolveSuccess(msg.message().getCategories());
+			if (scanningCategories == null) scanningCategories = new ArrayList<>();
+			var category = scanningCategories.stream()
+				.filter(v -> v.getCategoryId().equals(msg.message().getCategoryId()))
+				.findAny();
+			if (category.isEmpty()) {
+				var c = new MemoryCategory(msg.message().getCategoryId(), msg.message().getCategoryName());
+				scanningCategories.add(c);
+				category = Optional.of(c);
+			}
+
+			var list = ((MemoryCategory) category.get()).getModifiableMockProducts();
+			var pId = msg.message().getProductId();
+			var pName = msg.message().getProductName();
+			var pCData = msg.message().getConstructionData();
+			if (pId.length() != 0) list.add(new MemoryProduct((MemoryCategory) category.get(), pId, pName, pCData));
+
+			if (msg.message().isFinished()) {
+				cachedCategories = scanningCategories;
+				categoriesQueryTask.resolveSuccess(scanningCategories);
+				scanningCategories = null;
+			}
+		});
+
+		messagesHandler.handleConnection(connection);
+	}
+
+	public void clearRemoteCache() {
+		cachedCategories = null;
+	}
+
+	/**
+	 * <p>
+	 * Obtain all categories. This value is controlled by remote service.
+	 * </p>
+	 * <p>
+	 * However, the return value of this method could be cached. If you just added
+	 * something from remote service, you'll have to restart game server or use
+	 * {@link #clearRemoteCache()}
+	 * </p>
+	 */
+	@Override
+	public Task<List<Category>> queryAllCategories() {
+		if (cachedCategories != null) return Task.resolved(cachedCategories);
+
+		if (categoriesQueryTask == null) {
+			categoriesQueryTask = new ManualTask<>();
+			connection.sendRawPacket(new MessageC2SQueryProducts().createRawPacket());
+		}
+
+		return categoriesQueryTask;
+	}
+
+	@Override
+	public Task<ProductMarketOverview> queryProductMarketOverview(Product product) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Task<List<Offer>> getOffers(UUID offerer) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Task<Offer> claimOffer(Offer offer) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Task<Offer> cancelOffer(Offer offer) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Task<Offer> listOffer(UUID offerer, Product product, OfferType type, int units, double pricePerUnit) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Task<InstantOfferExecuteResult> instantOffer(Product product, OfferType type, int units, double balance) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void subscribeToOfferFilledEvents(Consumer<Offer> consumer) {
+		// TODO Auto-generated method stub
+
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/StonksRemoteService.java
+++ b/core/src/main/java/stonks/core/service/remote/StonksRemoteService.java
@@ -207,13 +207,13 @@ public class StonksRemoteService implements StonksService {
 	}
 
 	@Override
-	public Task<Offer> claimOffer(Offer offer) {
+	public Task<Offer> claimOffer(UUID offerer, UUID offerId) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public Task<Offer> cancelOffer(Offer offer) {
+	public Task<Offer> cancelOffer(UUID offerer, UUID offerId) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/core/src/main/java/stonks/core/service/remote/message/ConnectionMessage.java
+++ b/core/src/main/java/stonks/core/service/remote/message/ConnectionMessage.java
@@ -1,0 +1,6 @@
+package stonks.core.service.remote.message;
+
+import stonks.core.net.Connection;
+
+public record ConnectionMessage<T extends Message>(Connection connection, T message) {
+}

--- a/core/src/main/java/stonks/core/service/remote/message/ConnectionMessage.java
+++ b/core/src/main/java/stonks/core/service/remote/message/ConnectionMessage.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package stonks.core.service.remote.message;
 
 import stonks.core.net.Connection;

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SAddOffer.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SAddOffer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.UUID;
+
+import stonks.core.market.OfferType;
+
+public class MessageC2SAddOffer implements Message {
+	public static final String ID = "c2s_addOffer";
+	private UUID offerer;
+	private String productId;
+	private OfferType type;
+	private int units;
+	private double pricePerUnit;
+	private long responseId;
+
+	public MessageC2SAddOffer(UUID offerer, String productId, OfferType type, int units, double pricePerUnit, long responseId) {
+		this.offerer = offerer;
+		this.productId = productId;
+		this.type = type;
+		this.units = units;
+		this.pricePerUnit = pricePerUnit;
+		this.responseId = responseId;
+	}
+
+	public MessageC2SAddOffer(DataInput input) throws IOException {
+		var msb = input.readLong();
+		var lsb = input.readLong();
+		this.offerer = new UUID(msb, lsb);
+		this.productId = input.readUTF();
+		this.type = OfferType.valueOf(input.readUTF().toUpperCase());
+		this.units = input.readInt();
+		this.pricePerUnit = input.readDouble();
+		this.responseId = input.readLong();
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public UUID getOfferer() { return offerer; }
+
+	public String getProductId() { return productId; }
+
+	public OfferType getType() { return type; }
+
+	public int getUnits() { return units; }
+
+	public double getPricePerUnit() { return pricePerUnit; }
+
+	public long getResponseId() { return responseId; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(offerer.getMostSignificantBits());
+		output.writeLong(offerer.getLeastSignificantBits());
+		output.writeUTF(productId);
+		output.writeUTF(type.toString());
+		output.writeInt(units);
+		output.writeDouble(pricePerUnit);
+		output.writeLong(responseId);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SGetOffers.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SGetOffers.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package stonks.core.service.remote.message;
 
 import java.io.DataInput;

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SGetOffers.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SGetOffers.java
@@ -1,0 +1,32 @@
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.UUID;
+
+public class MessageC2SGetOffers implements Message {
+	public static final String ID = "c2s_getOffers";
+	private UUID offerer;
+
+	public MessageC2SGetOffers(UUID offerer) {
+		this.offerer = offerer;
+	}
+
+	public MessageC2SGetOffers(DataInput input) throws IOException {
+		var msb = input.readLong();
+		var lsb = input.readLong();
+		this.offerer = new UUID(msb, lsb);
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public UUID getOfferer() { return offerer; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(offerer.getMostSignificantBits());
+		output.writeLong(offerer.getLeastSignificantBits());
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SInstantOffer.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SInstantOffer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import stonks.core.market.OfferType;
+
+public class MessageC2SInstantOffer implements Message {
+	public static final String ID = "c2s_instantOffer";
+	private long responseId;
+	private String productId;
+	private OfferType type;
+	private int units;
+	private double balance;
+
+	public MessageC2SInstantOffer(long responseId, String productId, OfferType type, int units, double balance) {
+		this.responseId = responseId;
+		this.productId = productId;
+		this.type = type;
+		this.units = units;
+		this.balance = balance;
+	}
+
+	public MessageC2SInstantOffer(DataInput input) throws IOException {
+		this.responseId = input.readLong();
+		this.productId = input.readUTF();
+		this.type = OfferType.valueOf(input.readUTF().toUpperCase());
+		this.units = input.readInt();
+		this.balance = input.readDouble();
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public long getResponseId() { return responseId; }
+
+	public String getProductId() { return productId; }
+
+	public OfferType getType() { return type; }
+
+	public int getUnits() { return units; }
+
+	public double getBalance() { return balance; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(responseId);
+		output.writeUTF(productId);
+		output.writeUTF(type.toString());
+		output.writeInt(units);
+		output.writeDouble(balance);
+	}
+
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SOfferOption.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SOfferOption.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.UUID;
+
+public class MessageC2SOfferOption implements Message {
+	public static enum Type {
+		CLAIM,
+		CANCEL;
+	}
+
+	public static final String ID = "c2s_offerOption";
+	private long responseId;
+	private UUID userId;
+	private UUID offerId;
+	private Type type;
+
+	public MessageC2SOfferOption(long responseId, UUID userId, UUID offerId, Type type) {
+		this.responseId = responseId;
+		this.userId = userId;
+		this.offerId = offerId;
+		this.type = type;
+	}
+
+	public MessageC2SOfferOption(DataInput input) throws IOException {
+		this.responseId = input.readLong();
+		long userMsb = input.readLong(), userLsb = input.readLong();
+		long offerMsb = input.readLong(), offerLsb = input.readLong();
+		this.userId = new UUID(userMsb, userLsb);
+		this.offerId = new UUID(offerMsb, offerLsb);
+		this.type = Type.valueOf(input.readUTF().toUpperCase());
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public long getResponseId() { return responseId; }
+
+	public UUID getUserId() { return userId; }
+
+	public UUID getOfferId() { return offerId; }
+
+	public Type getType() { return type; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(responseId);
+		output.writeLong(userId.getMostSignificantBits());
+		output.writeLong(userId.getLeastSignificantBits());
+		output.writeLong(offerId.getMostSignificantBits());
+		output.writeLong(offerId.getLeastSignificantBits());
+		output.writeUTF(type.toString());
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SQueryProductOverview.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SQueryProductOverview.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import stonks.core.product.Product;
+
+public class MessageC2SQueryProductOverview implements Message {
+	public static final String ID = "c2s_queryProductOverview";
+	private String productId;
+
+	public MessageC2SQueryProductOverview(String productId) {
+		this.productId = productId;
+	}
+
+	public MessageC2SQueryProductOverview(Product product) {
+		this.productId = product.getProductId();
+	}
+
+	public MessageC2SQueryProductOverview(DataInput input) throws IOException {
+		this.productId = input.readUTF();
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public String getProductId() { return productId; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeUTF(productId);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SQueryProducts.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SQueryProducts.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package stonks.core.service.remote.message;
 
 import java.io.DataInput;

--- a/core/src/main/java/stonks/core/service/remote/message/MessageC2SQueryProducts.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageC2SQueryProducts.java
@@ -1,0 +1,19 @@
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class MessageC2SQueryProducts implements Message {
+	public static final String ID = "c2s_queryProducts";
+
+	public MessageC2SQueryProducts(DataInput input) throws IOException {}
+
+	public MessageC2SQueryProducts() {}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2CAddOffer.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2CAddOffer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import stonks.core.market.Offer;
+import stonks.core.product.Product;
+
+public class MessageS2CAddOffer implements Message {
+	public static final String ID = "s2c_addOffer";
+	private String errorMessage;
+	private Offer offer;
+	private long responseId;
+
+	public MessageS2CAddOffer(long responseId, Offer offer) {
+		this.responseId = responseId;
+		this.offer = offer;
+	}
+
+	public MessageS2CAddOffer(long responseId, String errorMessage) {
+		this.responseId = responseId;
+		this.errorMessage = errorMessage;
+	}
+
+	public MessageS2CAddOffer(Function<String, Product> products, DataInput input) throws IOException {
+		this.responseId = input.readLong();
+
+		if (!input.readBoolean()) {
+			this.errorMessage = input.readUTF();
+			return;
+		}
+
+		this.offer = MessageS2COffersList.deserializeOffer(products, input);
+	}
+
+	public static MessageDeserializer createDeserializer(Function<String, Product> products) {
+		return input -> new MessageS2CAddOffer(products, input);
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public long getResponseId() { return responseId; }
+
+	public Optional<String> getErrorMessage() { return Optional.ofNullable(errorMessage); }
+
+	public Offer getOffer() { return offer; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(responseId);
+
+		if (errorMessage != null) {
+			output.writeBoolean(false);
+			output.writeUTF(errorMessage);
+			return;
+		}
+
+		output.writeBoolean(true);
+		MessageS2COffersList.serializeOffer(offer, output);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2CInstantOffer.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2CInstantOffer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Optional;
+
+import stonks.core.exec.InstantOfferExecuteResult;
+
+public class MessageS2CInstantOffer implements Message {
+	public static final String ID = "s2c_instantOffer";
+	private long responseId;
+	private String errorMessage;
+	private int units;
+	private double balance;
+
+	public MessageS2CInstantOffer(long responseId, int units, double balance) {
+		this.responseId = responseId;
+		this.units = units;
+		this.balance = balance;
+	}
+
+	public MessageS2CInstantOffer(long responseId, String errorMessage) {
+		this.responseId = responseId;
+		this.errorMessage = errorMessage;
+	}
+
+	public MessageS2CInstantOffer(DataInput input) throws IOException {
+		this.responseId = input.readLong();
+
+		if (!input.readBoolean()) {
+			this.errorMessage = input.readUTF();
+			return;
+		}
+
+		this.units = input.readInt();
+		this.balance = input.readDouble();
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public long getResponseId() { return responseId; }
+
+	public Optional<String> getErrorMessage() { return Optional.ofNullable(errorMessage); }
+
+	public InstantOfferExecuteResult getResult() { return new InstantOfferExecuteResult(units, balance); }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(responseId);
+
+		if (errorMessage != null) {
+			output.writeBoolean(false);
+			output.writeUTF(errorMessage);
+			return;
+		}
+
+		output.writeBoolean(true);
+		output.writeInt(units);
+		output.writeDouble(balance);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2COfferFilled.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2COfferFilled.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.function.Function;
+
+import stonks.core.market.Offer;
+import stonks.core.product.Product;
+
+public class MessageS2COfferFilled implements Message {
+	public static final String ID = "s2c_offerFilled";
+	private Offer offer;
+
+	public MessageS2COfferFilled(Offer offer) {
+		this.offer = offer;
+	}
+
+	public MessageS2COfferFilled(Function<String, Product> products, DataInput input) throws IOException {
+		this.offer = MessageS2COffersList.deserializeOffer(products, input);
+	}
+
+	public static MessageDeserializer createDeserializer(Function<String, Product> products) {
+		return input -> new MessageS2COfferFilled(products, input);
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public Offer getOffer() { return offer; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		MessageS2COffersList.serializeOffer(offer, output);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2COfferOption.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2COfferOption.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import stonks.core.market.Offer;
+import stonks.core.product.Product;
+
+public class MessageS2COfferOption implements Message {
+	public static final String ID = "s2c_offerOption";
+	private long responseId;
+	private String errorMessage;
+	private Offer offer;
+
+	public MessageS2COfferOption(long responseId, Offer offer) {
+		this.responseId = responseId;
+		this.offer = offer;
+	}
+
+	public MessageS2COfferOption(long responseId, String errorMessage) {
+		this.responseId = responseId;
+		this.errorMessage = errorMessage;
+	}
+
+	public MessageS2COfferOption(Function<String, Product> products, DataInput input) throws IOException {
+		this.responseId = input.readLong();
+
+		if (!input.readBoolean()) {
+			this.errorMessage = input.readUTF();
+			return;
+		}
+
+		this.offer = MessageS2COffersList.deserializeOffer(products, input);
+	}
+
+	public static MessageDeserializer createDeserializer(Function<String, Product> products) {
+		return input -> new MessageS2COfferOption(products, input);
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public long getResponseId() { return responseId; }
+
+	public Optional<String> getErrorMessage() { return Optional.ofNullable(errorMessage); }
+
+	public Offer getOffer() { return offer; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(responseId);
+
+		if (errorMessage != null) {
+			output.writeBoolean(false);
+			output.writeUTF(errorMessage);
+			return;
+		}
+
+		output.writeBoolean(true);
+		MessageS2COffersList.serializeOffer(offer, output);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2COffersList.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2COffersList.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package stonks.core.service.remote.message;
 
 import java.io.DataInput;

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2COffersList.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2COffersList.java
@@ -103,7 +103,7 @@ public class MessageS2COffersList implements Message {
 		for (var e : offers) serializeOffer(e, output);
 	}
 
-	private static void serializeOffer(Offer offer, DataOutput output) throws IOException {
+	public static void serializeOffer(Offer offer, DataOutput output) throws IOException {
 		output.writeLong(offer.getOfferId().getMostSignificantBits());
 		output.writeLong(offer.getOfferId().getLeastSignificantBits());
 		output.writeLong(offer.getOffererId().getMostSignificantBits());
@@ -116,7 +116,7 @@ public class MessageS2COffersList implements Message {
 		output.writeDouble(offer.getPricePerUnit());
 	}
 
-	private static Offer deserializeOffer(Function<String, Product> products, DataInput input) throws IOException {
+	public static Offer deserializeOffer(Function<String, Product> products, DataInput input) throws IOException {
 		var offerIdMsb = input.readLong();
 		var offerIdLsb = input.readLong();
 		var offerId = new UUID(offerIdMsb, offerIdLsb);

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2COffersList.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2COffersList.java
@@ -1,0 +1,114 @@
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import stonks.core.market.Offer;
+import stonks.core.market.OfferType;
+import stonks.core.product.Product;
+
+public class MessageS2COffersList implements Message {
+	public static final String ID = "s2c_offersList";
+	private UUID offerer;
+	private String errorMessage;
+	private List<Offer> offers;
+
+	public MessageS2COffersList(UUID offerer, List<Offer> offers) {
+		this.offerer = offerer;
+		this.offers = offers;
+	}
+
+	public MessageS2COffersList(UUID offerer, String errorMessage) {
+		this.offerer = offerer;
+		this.errorMessage = errorMessage;
+	}
+
+	public MessageS2COffersList(Function<String, Product> products, DataInput input) throws IOException {
+		var msb = input.readLong();
+		var lsb = input.readLong();
+		this.offerer = new UUID(msb, lsb);
+
+		if (!input.readBoolean()) {
+			this.errorMessage = input.readUTF();
+			return;
+		}
+
+		this.offers = new ArrayList<>();
+		var count = input.readInt();
+
+		for (int i = 0; i < count; i++) {
+			var e = deserializeOffer(products, input);
+			if (e == null) {
+				this.errorMessage = "Local: One or more product IDs are not populated";
+				return;
+			}
+
+			this.offers.add(e);
+		}
+	}
+
+	public static MessageDeserializer createDeserializer(Function<String, Product> products) {
+		return input -> new MessageS2COffersList(products, input);
+	}
+
+	public UUID getOfferer() { return offerer; }
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public List<Offer> getOffers() { return offers; }
+
+	public Optional<String> getErrorMessage() { return Optional.ofNullable(errorMessage); }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeLong(offerer.getMostSignificantBits());
+		output.writeLong(offerer.getLeastSignificantBits());
+
+		if (errorMessage != null) {
+			output.writeBoolean(false);
+			output.writeUTF(errorMessage);
+			return;
+		}
+
+		output.writeBoolean(true);
+		output.writeInt(offers.size());
+		for (var e : offers) serializeOffer(e, output);
+	}
+
+	private static void serializeOffer(Offer offer, DataOutput output) throws IOException {
+		output.writeLong(offer.getOfferId().getMostSignificantBits());
+		output.writeLong(offer.getOfferId().getLeastSignificantBits());
+		output.writeLong(offer.getOffererId().getMostSignificantBits());
+		output.writeLong(offer.getOffererId().getLeastSignificantBits());
+		output.writeUTF(offer.getProduct().getProductId());
+		output.writeUTF(offer.getType().toString());
+		output.writeInt(offer.getTotalUnits());
+		output.writeInt(offer.getClaimedUnits());
+		output.writeInt(offer.getFilledUnits());
+		output.writeDouble(offer.getPricePerUnit());
+	}
+
+	private static Offer deserializeOffer(Function<String, Product> products, DataInput input) throws IOException {
+		var offerIdMsb = input.readLong();
+		var offerIdLsb = input.readLong();
+		var offerId = new UUID(offerIdMsb, offerIdLsb);
+		var offererMsb = input.readLong();
+		var offererLsb = input.readLong();
+		var offerer = new UUID(offererMsb, offererLsb);
+		var product = products.apply(input.readUTF());
+		if (product == null) return null;
+		var type = OfferType.valueOf(input.readUTF().toUpperCase());
+		var total = input.readInt();
+		var claimed = input.readInt();
+		var filled = input.readInt();
+		var price = input.readDouble();
+		return new Offer(offerId, offerer, product, type, total, claimed, filled, price);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2CQueryProductOverview.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2CQueryProductOverview.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import stonks.core.market.OverviewOffer;
+import stonks.core.market.ProductMarketOverview;
+
+public class MessageS2CQueryProductOverview implements Message {
+	public static final String ID = "s2c_queryProductOverview";
+	private String errorMessage;
+	private String productId;
+	private List<OverviewOffer> buyOffers;
+	private List<OverviewOffer> sellOffers;
+
+	public MessageS2CQueryProductOverview(ProductMarketOverview overview) {
+		this.productId = overview.getProduct().getProductId();
+		this.buyOffers = overview.getBuyOffers().getEntries();
+		this.sellOffers = overview.getSellOffers().getEntries();
+	}
+
+	public MessageS2CQueryProductOverview(String productId, String errorMessage) {
+		this.productId = productId;
+		this.errorMessage = errorMessage;
+	}
+
+	public MessageS2CQueryProductOverview(DataInput input) throws IOException {
+		this.productId = input.readUTF();
+
+		if (!input.readBoolean()) {
+			this.errorMessage = input.readUTF();
+			return;
+		}
+
+		this.buyOffers = new ArrayList<>();
+		var buyOffersCount = input.readInt();
+		for (int i = 0; i < buyOffersCount; i++) buyOffers.add(deserializeOfferOverview(input));
+
+		this.sellOffers = new ArrayList<>();
+		var sellOffersCount = input.readInt();
+		for (int i = 0; i < sellOffersCount; i++) sellOffers.add(deserializeOfferOverview(input));
+	}
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	public String getProductId() { return productId; }
+
+	public Optional<String> getErrorMessage() { return Optional.ofNullable(errorMessage); }
+
+	public List<OverviewOffer> getBuyOffers() { return buyOffers; }
+
+	public List<OverviewOffer> getSellOffers() { return sellOffers; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		output.writeUTF(productId);
+
+		if (errorMessage != null) {
+			output.writeBoolean(false);
+			output.writeUTF(errorMessage);
+			return;
+		}
+
+		output.writeBoolean(true);
+		output.writeInt(buyOffers.size());
+		for (var e : buyOffers) serializeOfferOverview(e, output);
+		output.writeInt(sellOffers.size());
+		for (var e : sellOffers) serializeOfferOverview(e, output);
+	}
+
+	private static void serializeOfferOverview(OverviewOffer entry, DataOutput output) throws IOException {
+		output.writeInt(entry.offers());
+		output.writeInt(entry.totalAvailableUnits());
+		output.writeDouble(entry.pricePerUnit());
+	}
+
+	private static OverviewOffer deserializeOfferOverview(DataInput input) throws IOException {
+		var offers = input.readInt();
+		var totalAvailableUnits = input.readInt();
+		var pricePerUnit = input.readDouble();
+		return new OverviewOffer(offers, totalAvailableUnits, pricePerUnit);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2CQueryProductsPartial.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2CQueryProductsPartial.java
@@ -1,0 +1,100 @@
+package stonks.core.service.remote.message;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Optional;
+
+import stonks.core.product.Product;
+
+/**
+ * <p>
+ * This packet uses "partial thing" when sending product declarations to
+ * platforms/front-ends.
+ * </p>
+ * <p>
+ * Basically, a single raw packet can only have up to 32768 bytes. If we put all
+ * products into a single packet, it would be filled up pretty quickly (assuming
+ * you are not using other adapters to save spaces).
+ * </p>
+ */
+public class MessageS2CQueryProductsPartial implements Message {
+	public static final String ID = "s2c_queryProductsPartial";
+	private String errorMessage;
+	private String categoryId;
+	private String categoryName;
+	private String productId;
+	private String productName;
+	private String constructionData;
+	private boolean isFinished;
+
+	public MessageS2CQueryProductsPartial(String categoryId, String categoryName, String productId, String productName, String constructionData, boolean isFinished) {
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
+		this.productId = productId;
+		this.productName = productName;
+		this.constructionData = constructionData;
+		this.isFinished = isFinished;
+	}
+
+	public MessageS2CQueryProductsPartial(String errorMessage) {
+		this.errorMessage = errorMessage;
+	}
+
+	public MessageS2CQueryProductsPartial(Product product, boolean isFinished) {
+		this.categoryId = product.getCategory().getCategoryId();
+		this.categoryName = product.getCategory().getCategoryName();
+		this.productId = product.getProductId();
+		this.productName = product.getProductName();
+		this.constructionData = product.getProductConstructionData();
+		this.isFinished = isFinished;
+	}
+
+	public MessageS2CQueryProductsPartial(DataInput input) throws IOException {
+		if (!input.readBoolean()) {
+			this.errorMessage = input.readUTF();
+			return;
+		}
+
+		this.categoryId = input.readUTF();
+		this.categoryName = input.readUTF();
+		this.productId = input.readUTF();
+		this.productName = input.readUTF();
+		this.constructionData = input.readUTF();
+		this.isFinished = input.readBoolean();
+	}
+
+	public Optional<String> getErrorMessage() { return Optional.ofNullable(errorMessage); }
+
+	public String getCategoryId() { return categoryId; }
+
+	public String getCategoryName() { return categoryName; }
+
+	public String getProductId() { return productId; }
+
+	public String getProductName() { return productName; }
+
+	public String getConstructionData() { return constructionData; }
+
+	public boolean isFinished() { return isFinished; }
+
+	@Override
+	public String getMessageId() { return ID; }
+
+	@Override
+	public void onMessageSerialize(DataOutput output) throws IOException {
+		if (errorMessage != null) {
+			output.writeBoolean(false);
+			output.writeUTF(errorMessage);
+			return;
+		}
+
+		output.writeBoolean(true);
+		output.writeUTF(categoryId);
+		output.writeUTF(categoryName);
+		output.writeUTF(productId);
+		output.writeUTF(productName);
+		output.writeUTF(constructionData);
+		output.writeBoolean(isFinished);
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessageS2CQueryProductsPartial.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessageS2CQueryProductsPartial.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package stonks.core.service.remote.message;
 
 import java.io.DataInput;

--- a/core/src/main/java/stonks/core/service/remote/message/MessagesHandler.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessagesHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.core.service.remote.message;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import stonks.core.net.Connection;
+import stonks.core.service.Emittable;
+
+public class MessagesHandler {
+	private Map<String, Message.MessageDeserializer> deserializers = new HashMap<>();
+	private Emittable<ConnectionMessage<?>> messagesEmitter = new Emittable<>();
+
+	public void registerDeserializer(String id, Message.MessageDeserializer deserializer) {
+		deserializers.put(id, deserializer);
+	}
+
+	public Message deserialize(ByteBuffer buffer) {
+		if (buffer.position() != 0) buffer.flip();
+		byte[] bs = new byte[buffer.limit()];
+		buffer.get(bs);
+		var input = new DataInputStream(new ByteArrayInputStream(bs));
+
+		try {
+			var id = input.readUTF();
+			var deserializer = deserializers.get(id);
+			if (deserializer == null) return null;
+			return deserializer.deserialize(input);
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends Message> void listenForMessage(Class<T> type, Consumer<ConnectionMessage<T>> consumer) {
+		messagesEmitter.listen(msg -> {
+			if (msg.message().getClass() == type) consumer.accept((ConnectionMessage<T>) msg);
+		});
+	}
+
+	public void handleConnection(Connection conn) {
+		conn.listenRawPackets((connection, raw) -> {
+			var message = this.deserialize(raw);
+			if (message == null) return;
+			messagesEmitter.emit(new ConnectionMessage<>(connection, message));
+		});
+	}
+}

--- a/core/src/main/java/stonks/core/service/remote/message/MessagesHandler.java
+++ b/core/src/main/java/stonks/core/service/remote/message/MessagesHandler.java
@@ -82,9 +82,7 @@ public class MessagesHandler {
 			var wrapped = new ConnectionMessage<>(connection, message);
 			messagesEmitter.emit(wrapped);
 			this.waiting.removeIf(waiting -> {
-				boolean b = waiting.clazz == message.getClass() && ((Predicate) waiting.isValid).test(message);
-				System.out.println(b);
-				if (b) {
+				if (waiting.clazz == message.getClass() && ((Predicate) waiting.isValid).test(message)) {
 					waiting.callback.accept((ConnectionMessage) wrapped);
 					return true;
 				}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
     api project(':core')
+    implementation 'org.slf4j:slf4j-api:2.0.7'
+    implementation 'org.slf4j:slf4j-simple:2.0.7'
+    implementation 'info.picocli:picocli:4.7.4'
+    implementation naharaToolkit('nahara-common-configurations')
 }
 
 tasks.named('test') {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+    api project(':core')
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/server/src/main/java/stonks/server/Main.java
+++ b/server/src/main/java/stonks/server/Main.java
@@ -22,6 +22,8 @@
 package stonks.server;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,7 @@ import stonks.server.cli.MainCommand;
 
 public class Main {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
+	public static final UUID DEFAULT_USER_UUID = UUID.nameUUIDFromBytes("Stonks".getBytes(StandardCharsets.UTF_8));
 
 	public static void main(String[] args) throws IOException {
 		System.exit(new CommandLine(new MainCommand()).execute(args));

--- a/server/src/main/java/stonks/server/Main.java
+++ b/server/src/main/java/stonks/server/Main.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server;
+
+import java.io.IOException;
+
+public class Main {
+	public static void main(String[] args) throws IOException {}
+}

--- a/server/src/main/java/stonks/server/cli/ClientCommand.java
+++ b/server/src/main/java/stonks/server/cli/ClientCommand.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.net.ClientConnection;
+import stonks.core.service.remote.StonksRemoteService;
+import stonks.server.Main;
+import stonks.server.cli.console.ConsoleInstance;
+import stonks.server.cli.converter.SocketAddressConverter;
+
+@Command(name = "client", description = "Connect to Stonks Server.")
+public class ClientCommand implements Callable<Integer> {
+	@ParentCommand
+	private MainCommand parent;
+
+	@Option(names = { "--address", "-A" },
+		converter = SocketAddressConverter.class,
+		description = {
+			"Specify a socket address to connect to Stonks Server.",
+			"Use inet:<address[:port]> for regular TCP address.",
+			"Use socket:<path/to/socket> for Unix socket."
+		})
+	public SocketAddress address = new InetSocketAddress(36636);
+
+	private ConsoleInstance console;
+
+	@Override
+	public Integer call() throws Exception {
+		Main.LOGGER.info("Connecting to {}...", address);
+		var channel = address instanceof UnixDomainSocketAddress
+			? SocketChannel.open(StandardProtocolFamily.UNIX)
+			: SocketChannel.open();
+		channel.connect(address);
+
+		var conn = new ClientConnection(channel, connection -> {
+			Main.LOGGER.info("Connected!");
+			connection.listenClose($ -> {
+				console.shouldStopConsole = true;
+				Main.LOGGER.info("Disconnected! Press Enter to close console.");
+			});
+		});
+
+		var service = new StonksRemoteService(conn);
+		console = new ConsoleInstance(service);
+		var thread = conn.createThread();
+		thread.start();
+
+		while (channel.isConnectionPending()) Thread.sleep(1);
+		console.startInCurrentThread();
+		Main.LOGGER.info("Console exited, stopping networking thread...");
+		conn.requestClose();
+		while (!conn.isClosed()) Thread.sleep(1);
+		Main.LOGGER.info("Goodbye!");
+		return 0;
+	}
+}

--- a/server/src/main/java/stonks/server/cli/MainCommand.java
+++ b/server/src/main/java/stonks/server/cli/MainCommand.java
@@ -19,20 +19,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.cli;
 
-import java.io.IOException;
+import nahara.common.configurations.Config;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import stonks.server.cli.converter.ConfigConverter;
+import stonks.server.cli.converter.ConfigurableProviderConverter;
+import stonks.server.service.ConfigurableProvider;
+import stonks.server.service.ServiceProviders;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+@Command(name = "stonks-server", subcommands = {
+	ServerCommand.class,
+	ClientCommand.class,
+})
+public class MainCommand {
+	@Option(names = { "--provider", "-P" },
+		converter = ConfigurableProviderConverter.class,
+		description = "Specify a service provider to use. Default is \"stonks:memory\".")
+	public ConfigurableProvider provider = ServiceProviders.MEMORY;
 
-import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
-
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
-
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
-	}
+	@Option(names = { "--config", "-C" },
+		converter = ConfigConverter.class,
+		description = "Specify configuration file for service provider.")
+	public Config configuration = new Config();
 }

--- a/server/src/main/java/stonks/server/cli/ServerCommand.java
+++ b/server/src/main/java/stonks/server/cli/ServerCommand.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli;
+
+import java.net.SocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.service.LocalStonksService;
+import stonks.core.service.remote.StonksRemoteServer;
+import stonks.server.Main;
+import stonks.server.cli.console.ConsoleInstance;
+import stonks.server.cli.converter.SocketAddressConverter;
+
+@Command(name = "server", description = "Start a new Stonks Server.")
+public class ServerCommand implements Callable<Integer> {
+	@ParentCommand
+	private MainCommand parent;
+
+	@Option(names = { "--address", "-A" },
+		converter = SocketAddressConverter.class,
+		description = {
+			"Specify a socket address to bind server.",
+			"Use inet:<address[:port]> for regular TCP address.",
+			"Use socket:<path/to/socket> for Unix socket.",
+			"You can specify more than 1 address."
+		})
+	public List<SocketAddress> addresses;
+
+	private List<Map.Entry<StonksRemoteServer, Thread>> servers = new ArrayList<>();
+
+	@Override
+	public Integer call() throws Exception {
+		Main.LOGGER.info("Starting service...");
+		var service = parent.provider.configure(parent.configuration);
+
+		if (service instanceof LocalStonksService local) {
+			Main.LOGGER.info("Local service found, loading data...");
+			local.loadServiceData();
+		}
+
+		for (var addr : addresses) {
+			Main.LOGGER.info("Starting networking thread for address " + addr + "...");
+
+			var serverChannel = addr instanceof UnixDomainSocketAddress
+				? ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+				: ServerSocketChannel.open();
+			if (addr instanceof UnixDomainSocketAddress unix) Files.deleteIfExists(unix.getPath());
+			serverChannel.bind(addr);
+			var server = new StonksRemoteServer(service, serverChannel);
+			var thread = server.getServer().createThread();
+			thread.start();
+			servers.add(Map.entry(server, thread));
+		}
+
+		Main.LOGGER.info("Service ready!");
+
+		// while (true) Thread.sleep(1000); // TODO No console mode
+		// Console will be in main thread
+		var console = new ConsoleInstance(service);
+		console.startInCurrentThread();
+		Main.LOGGER.info("Console exited, stopping networking threads...");
+
+		for (var server : servers) {
+			var addr = server.getKey().getServer().getServer().getLocalAddress();
+			server.getKey().getServer().stop();
+			while (server.getValue().isAlive()) Thread.sleep(1);
+			server.getKey().getServer().getServer().close();
+			Main.LOGGER.info("Stopped networking thread for address {}", addr);
+		}
+
+		// TODO stop service
+		if (service instanceof LocalStonksService local) {
+			Main.LOGGER.info("Saving service data...");
+			local.saveServiceData();
+		}
+
+		Main.LOGGER.info("Goodbye!");
+		return 0;
+	}
+}

--- a/server/src/main/java/stonks/server/cli/console/AddOfferCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/AddOfferCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli.console;
+
+import java.util.UUID;
+
+import nahara.common.tasks.Task;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.market.Offer;
+import stonks.core.market.OfferType;
+import stonks.core.service.remote.RemoteServiceException;
+import stonks.server.Main;
+
+@Command(name = "add-offer", description = "Add new offer to Stonks.")
+public class AddOfferCommand implements AsyncConsoleCommand<Offer> {
+	@ParentCommand
+	public ConsoleInstance parent;
+
+	@Option(names = { "--uuid", "-U" }, description = "User's unique ID. Leave blank for default UUID.")
+	public UUID uuid = Main.DEFAULT_USER_UUID;
+
+	@Parameters(paramLabel = "ID", description = "Product ID.", index = "0")
+	public String productId;
+
+	@Parameters(paramLabel = "Type", description = "Offer type.", index = "1")
+	public OfferType type;
+
+	@Parameters(paramLabel = "Units", description = "Number of units.", index = "2")
+	public int units;
+
+	@Parameters(paramLabel = "Price", description = "Price per unit.", index = "3")
+	public double pricePerUnit;
+
+	@Override
+	public Task<Offer> getTask() throws Exception {
+		return parent.service.queryAllCategories()
+			.andThen(categories -> categories.stream()
+				.flatMap(category -> category.getProducts().stream())
+				.filter(product -> product.getProductId().equals(productId))
+				.findAny()
+				.map(product -> parent.service.listOffer(uuid, product, type, units, pricePerUnit))
+				.orElse(Task.failed(new RemoteServiceException("Product with ID " + productId + " does not exists!"))));
+	}
+
+	@Override
+	public void onSuccess(Offer obj) throws Exception {
+		ConsoleInstance.LOGGER.info("New offer listed: {} {}x {} at ${}/ea",
+			obj.getType(),
+			obj.getTotalUnits(),
+			obj.getProduct().getProductId(),
+			obj.getPricePerUnit());
+	}
+
+	@Override
+	public void onFailure(Throwable t) throws Exception {
+		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		ConsoleInstance.LOGGER.error("Failed to query add offer: " + t.getMessage());
+	}
+}

--- a/server/src/main/java/stonks/server/cli/console/CancelOfferCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/CancelOfferCommand.java
@@ -21,39 +21,39 @@
  */
 package stonks.server.cli.console;
 
-import java.util.List;
+import java.util.UUID;
 
 import nahara.common.tasks.Task;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
-import stonks.core.product.Category;
+import stonks.core.market.Offer;
 import stonks.core.service.ServiceException;
+import stonks.server.Main;
 
-@Command(name = "list-products", description = "List all products from service.")
-public class ListProductsCommand implements AsyncConsoleCommand<List<Category>> {
+@Command(name = "cancel-offer", description = "Cancel offer.")
+public class CancelOfferCommand implements AsyncConsoleCommand<Offer> {
 	@ParentCommand
 	public ConsoleInstance parent;
 
-	@Override
-	public Task<List<Category>> getTask() throws Exception { return parent.service.queryAllCategories(); }
+	@Option(names = { "--uuid", "-U" }, description = "User's unique ID. Leave blank for default UUID.")
+	public UUID uuid = Main.DEFAULT_USER_UUID;
+
+	@Parameters(paramLabel = "ID", description = "ID of the offer to cancel.")
+	public UUID offerId;
 
 	@Override
-	public void onSuccess(List<Category> obj) throws Exception {
-		ConsoleInstance.LOGGER.info("Found {} categories:", obj.size());
+	public Task<Offer> getTask() throws Exception { return parent.service.cancelOffer(uuid, offerId); }
 
-		for (var category : obj) {
-			ConsoleInstance.LOGGER.info("* Category: {} (Name = {})", category.getCategoryId(),
-				category.getCategoryName());
-			for (var product : category.getProducts()) {
-				ConsoleInstance.LOGGER.info("  * Product: {} (Name = {})", product.getProductId(),
-					product.getProductName());
-			}
-		}
+	@Override
+	public void onSuccess(Offer obj) throws Exception {
+		ConsoleInstance.LOGGER.info("Canceled offer successfully!");
 	}
 
 	@Override
 	public void onFailure(Throwable t) throws Exception {
 		if (!(t instanceof ServiceException)) t.printStackTrace();
-		ConsoleInstance.LOGGER.error("Failed to query categories: " + t.getMessage());
+		ConsoleInstance.LOGGER.error("Failed to cancel offer: " + t.getMessage());
 	}
 }

--- a/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
+++ b/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
@@ -51,6 +51,17 @@ public class ConsoleInstance {
 	}
 
 	public void startInCurrentThread() {
+		service.subscribeToOfferFilledEvents(offer -> {
+			if (shouldStopConsole) return;
+			LOGGER.info("[{}] Offer filled for {}! {} {}x {} for ${}/ea",
+				offer.getOfferId(),
+				offer.getOffererId(),
+				offer.getType(),
+				offer.getTotalUnits(),
+				offer.getProduct().getProductId(),
+				offer.getPricePerUnit());
+		});
+
 		var console = System.console();
 
 		if (console == null) {

--- a/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
+++ b/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
@@ -36,8 +36,9 @@ import stonks.core.service.StonksService;
 		ListProductsCommand.class,
 		ProductOverviewCommand.class,
 		ListOffersCommand.class,
-		// TODO
 		AddOfferCommand.class,
+		ClaimOfferCommand.class,
+		CancelOfferCommand.class,
 	})
 public class ConsoleInstance {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Console");

--- a/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
+++ b/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
@@ -19,20 +19,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.cli.console;
 
-import java.io.IOException;
+import java.util.Scanner;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
+import picocli.CommandLine.Command;
+import stonks.core.service.StonksService;
 
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
+@Command(name = "<console>",
+	subcommands = {
+		ExitCommand.class,
+		ListProductsCommand.class,
+		ProductOverviewCommand.class,
+		ListOffersCommand.class,
+	})
+public class ConsoleInstance {
+	public static final Logger LOGGER = LoggerFactory.getLogger("Console");
+	public StonksService service;
+	public boolean shouldStopConsole = false;
 
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
+	public ConsoleInstance(StonksService service) {
+		this.service = service;
+	}
+
+	public void startInCurrentThread() {
+		var console = System.console();
+
+		if (console == null) {
+			LOGGER.warn("System.console() returns null - Unsupported TTY/Missing console.");
+			LOGGER.warn("Scanner will be used to read data from standard input.");
+
+			var scanner = new Scanner(System.in);
+			LOGGER.info("Console ready!");
+			while (!shouldStopConsole) sendCommand(scanner.nextLine());
+			scanner.close();
+		} else {
+			LOGGER.info("Console ready!");
+			while (!shouldStopConsole) console.readLine();
+		}
+	}
+
+	private void sendCommand(String raw) {
+		if (shouldStopConsole) return;
+		new CommandLine(this).execute(raw.split(" "));
 	}
 }

--- a/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
+++ b/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
@@ -39,6 +39,7 @@ import stonks.core.service.StonksService;
 		AddOfferCommand.class,
 		ClaimOfferCommand.class,
 		CancelOfferCommand.class,
+		InstantOfferCommand.class,
 	})
 public class ConsoleInstance {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Console");

--- a/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
+++ b/server/src/main/java/stonks/server/cli/console/ConsoleInstance.java
@@ -36,6 +36,8 @@ import stonks.core.service.StonksService;
 		ListProductsCommand.class,
 		ProductOverviewCommand.class,
 		ListOffersCommand.class,
+		// TODO
+		AddOfferCommand.class,
 	})
 public class ConsoleInstance {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Console");

--- a/server/src/main/java/stonks/server/cli/console/ExitCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ExitCommand.java
@@ -19,20 +19,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.cli.console;
 
-import java.io.IOException;
+import java.util.concurrent.Callable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
 
-import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
+@Command(name = "exit", description = "Exit console")
+public class ExitCommand implements Callable<Integer> {
+	@ParentCommand
+	public ConsoleInstance parent;
 
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
-
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
+	@Override
+	public Integer call() throws Exception {
+		parent.shouldStopConsole = true;
+		return 0;
 	}
 }

--- a/server/src/main/java/stonks/server/cli/console/InstantOfferCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/InstantOfferCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli.console;
+
+import nahara.common.tasks.Task;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.exec.InstantOfferExecuteResult;
+import stonks.core.market.OfferType;
+import stonks.core.service.remote.RemoteServiceException;
+
+@Command(name = "instant-offer", description = "Perform instant offer.")
+public class InstantOfferCommand implements AsyncConsoleCommand<InstantOfferExecuteResult> {
+	@ParentCommand
+	public ConsoleInstance parent;
+
+	@Parameters(paramLabel = "ID", description = "Product ID.", index = "0")
+	public String productId;
+
+	@Parameters(paramLabel = "Type", description = "Offer type.", index = "1")
+	public OfferType type;
+
+	@Parameters(paramLabel = "Units", description = "Number of units to instant buy/sell.", index = "2")
+	public int units;
+
+	@Parameters(paramLabel = "Balance", description = "Account balance.", index = "3")
+	public double balance;
+
+	@Override
+	public Task<InstantOfferExecuteResult> getTask() throws Exception {
+		return parent.service.queryAllCategories()
+			.andThen(categories -> categories.stream()
+				.flatMap(category -> category.getProducts().stream())
+				.filter(product -> product.getProductId().equals(productId))
+				.findAny()
+				.map(product -> parent.service.instantOffer(product, type, units, balance))
+				.orElse(Task.failed(new RemoteServiceException("Product with ID " + productId + " does not exists!"))));
+	}
+
+	@Override
+	public void onSuccess(InstantOfferExecuteResult obj) throws Exception {
+		ConsoleInstance.LOGGER.info("Performed instant offer: {} units moved, {} units not moved and ${} left.",
+			units - obj.units(), obj.units(), obj.balance());
+	}
+
+	@Override
+	public void onFailure(Throwable t) throws Exception {
+		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		ConsoleInstance.LOGGER.error("Failed to perform instant offer: " + t.getMessage());
+	}
+}

--- a/server/src/main/java/stonks/server/cli/console/ListOffersCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ListOffersCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli.console;
+
+import java.util.List;
+import java.util.UUID;
+
+import nahara.common.tasks.Task;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.market.Offer;
+import stonks.core.service.remote.RemoteServiceException;
+
+@Command(name = "list-offers", description = "List all offers that was created by someone.")
+public class ListOffersCommand implements AsyncConsoleCommand<List<Offer>> {
+	@ParentCommand
+	public ConsoleInstance parent;
+
+	@Parameters(paramLabel = "UUID", description = "UUID of the user.")
+	public UUID uuid;
+
+	@Override
+	public Task<List<Offer>> getTask() throws Exception { return parent.service.getOffers(uuid); }
+
+	@Override
+	public void onSuccess(List<Offer> obj) throws Exception {
+		ConsoleInstance.LOGGER.info("Listing all offers by " + uuid + ": {} offers", obj.size());
+
+		for (var offer : obj) {
+			ConsoleInstance.LOGGER.info("* Offer: {}", offer.getOfferId());
+			ConsoleInstance.LOGGER.info("  * Product: {}", offer.getProduct().getProductId());
+			ConsoleInstance.LOGGER.info("  * Offer type: {}", offer.getType().toString());
+			ConsoleInstance.LOGGER.info("  * Status: {} / {} / {}",
+				offer.getClaimedUnits(), offer.getFilledUnits(), offer.getTotalUnits());
+			ConsoleInstance.LOGGER.info("            (Claimed / Filled / Total)");
+		}
+	}
+
+	@Override
+	public void onFailure(Throwable t) throws Exception {
+		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		ConsoleInstance.LOGGER.error("Failed to list offers: " + t.getMessage());
+	}
+}

--- a/server/src/main/java/stonks/server/cli/console/ListOffersCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ListOffersCommand.java
@@ -26,18 +26,19 @@ import java.util.UUID;
 
 import nahara.common.tasks.Task;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 import stonks.core.market.Offer;
 import stonks.core.service.remote.RemoteServiceException;
+import stonks.server.Main;
 
 @Command(name = "list-offers", description = "List all offers that was created by someone.")
 public class ListOffersCommand implements AsyncConsoleCommand<List<Offer>> {
 	@ParentCommand
 	public ConsoleInstance parent;
 
-	@Parameters(paramLabel = "UUID", description = "UUID of the user.")
-	public UUID uuid;
+	@Option(names = { "--uuid", "-U" }, description = "User's unique ID. Leave blank for default UUID.")
+	public UUID uuid = Main.DEFAULT_USER_UUID;
 
 	@Override
 	public Task<List<Offer>> getTask() throws Exception { return parent.service.getOffers(uuid); }

--- a/server/src/main/java/stonks/server/cli/console/ListOffersCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ListOffersCommand.java
@@ -29,7 +29,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 import stonks.core.market.Offer;
-import stonks.core.service.remote.RemoteServiceException;
+import stonks.core.service.ServiceException;
 import stonks.server.Main;
 
 @Command(name = "list-offers", description = "List all offers that was created by someone.")
@@ -59,7 +59,7 @@ public class ListOffersCommand implements AsyncConsoleCommand<List<Offer>> {
 
 	@Override
 	public void onFailure(Throwable t) throws Exception {
-		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		if (!(t instanceof ServiceException)) t.printStackTrace();
 		ConsoleInstance.LOGGER.error("Failed to list offers: " + t.getMessage());
 	}
 }

--- a/server/src/main/java/stonks/server/cli/console/ListProductsCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ListProductsCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli.console;
+
+import java.util.List;
+
+import nahara.common.tasks.Task;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.product.Category;
+import stonks.core.service.remote.RemoteServiceException;
+
+@Command(name = "list-products", description = "List all products from service.")
+public class ListProductsCommand implements AsyncConsoleCommand<List<Category>> {
+	@ParentCommand
+	public ConsoleInstance parent;
+
+	@Override
+	public Task<List<Category>> getTask() throws Exception { return parent.service.queryAllCategories(); }
+
+	@Override
+	public void onSuccess(List<Category> obj) throws Exception {
+		ConsoleInstance.LOGGER.info("Found {} categories:", obj.size());
+
+		for (var category : obj) {
+			ConsoleInstance.LOGGER.info("* Category: {} (Name = {})", category.getCategoryId(),
+				category.getCategoryName());
+			for (var product : category.getProducts()) {
+				ConsoleInstance.LOGGER.info("  * Product: {} (Name = {})", product.getProductId(),
+					product.getProductName());
+			}
+		}
+	}
+
+	@Override
+	public void onFailure(Throwable t) throws Exception {
+		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		ConsoleInstance.LOGGER.error("Failed to query categories: " + t.getMessage());
+	}
+}

--- a/server/src/main/java/stonks/server/cli/console/ProductOverviewCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ProductOverviewCommand.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.cli.console;
+
+import nahara.common.tasks.Task;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+import stonks.core.market.OverviewOffersList;
+import stonks.core.market.ProductMarketOverview;
+import stonks.core.service.remote.RemoteServiceException;
+
+@Command(name = "product", description = "View product overview.")
+public class ProductOverviewCommand implements AsyncConsoleCommand<ProductMarketOverview> {
+	@ParentCommand
+	public ConsoleInstance parent;
+
+	@Parameters(paramLabel = "ID", description = "Product ID.")
+	public String productId;
+
+	@Override
+	public Task<ProductMarketOverview> getTask() throws Exception {
+		return parent.service
+			.queryAllCategories()
+			.andThen(categories -> categories.stream()
+				.flatMap(category -> category.getProducts().stream())
+				.filter(product -> product.getProductId().equals(productId))
+				.findAny()
+				.map(product -> parent.service.queryProductMarketOverview(product))
+				.orElse(Task.failed(new RemoteServiceException("Product with ID " + productId + " does not exists!"))));
+	}
+
+	@Override
+	public void onSuccess(ProductMarketOverview obj) throws Exception {
+		ConsoleInstance.LOGGER.info("Product Overview for {}", obj.getProduct().getProductId());
+		ConsoleInstance.LOGGER.info("* Product name: {}", obj.getProduct().getProductName());
+		ConsoleInstance.LOGGER.info("* Construction data: {}", obj.getProduct().getProductConstructionData());
+		ConsoleInstance.LOGGER.info("* Buy offers: {} offers", obj.getBuyOffers().getEntries().size());
+		printOffersList(obj.getBuyOffers());
+		ConsoleInstance.LOGGER.info("* Sell offers: {} offers", obj.getSellOffers().getEntries().size());
+		printOffersList(obj.getSellOffers());
+	}
+
+	private void printOffersList(OverviewOffersList list) {
+		if (list.getEntries().size() == 0) {
+			ConsoleInstance.LOGGER.info("  * No offers!");
+			return;
+		}
+
+		var computed = list.compute();
+		if (computed.isEmpty()) {
+			ConsoleInstance.LOGGER.info("  * Failed to compute pricing");
+		} else {
+			ConsoleInstance.LOGGER.info("  * Avg. {} / Max. {} / Min. {}",
+				computed.get().average(), computed.get().max(), computed.get().min());
+		}
+
+		for (var e : list.getEntries()) {
+			ConsoleInstance.LOGGER.info("  * {} {}x units for ${} in {} offers",
+				list.getType(), e.totalAvailableUnits(), e.pricePerUnit(), e.offers());
+		}
+	}
+
+	@Override
+	public void onFailure(Throwable t) throws Exception {
+		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		ConsoleInstance.LOGGER.error("Failed to query product overview: " + t.getMessage());
+	}
+}

--- a/server/src/main/java/stonks/server/cli/console/ProductOverviewCommand.java
+++ b/server/src/main/java/stonks/server/cli/console/ProductOverviewCommand.java
@@ -27,6 +27,7 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 import stonks.core.market.OverviewOffersList;
 import stonks.core.market.ProductMarketOverview;
+import stonks.core.service.ServiceException;
 import stonks.core.service.remote.RemoteServiceException;
 
 @Command(name = "product", description = "View product overview.")
@@ -82,7 +83,7 @@ public class ProductOverviewCommand implements AsyncConsoleCommand<ProductMarket
 
 	@Override
 	public void onFailure(Throwable t) throws Exception {
-		if (!(t instanceof RemoteServiceException)) t.printStackTrace();
+		if (!(t instanceof ServiceException)) t.printStackTrace();
 		ConsoleInstance.LOGGER.error("Failed to query product overview: " + t.getMessage());
 	}
 }

--- a/server/src/main/java/stonks/server/cli/converter/ConfigConverter.java
+++ b/server/src/main/java/stonks/server/cli/converter/ConfigConverter.java
@@ -19,20 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.cli.converter;
 
-import java.io.IOException;
+import java.io.File;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import nahara.common.configurations.Config;
+import picocli.CommandLine.ITypeConverter;
 
-import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
-
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
-
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
+public class ConfigConverter implements ITypeConverter<Config> {
+	@Override
+	public Config convert(String value) throws Exception {
+		return Config.parseConfig(new File(value));
 	}
 }

--- a/server/src/main/java/stonks/server/cli/converter/ConfigurableProviderConverter.java
+++ b/server/src/main/java/stonks/server/cli/converter/ConfigurableProviderConverter.java
@@ -19,20 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.cli.converter;
 
-import java.io.IOException;
+import picocli.CommandLine.ITypeConverter;
+import stonks.server.service.ConfigurableProvider;
+import stonks.server.service.ServiceProviders;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
-
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
-
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
+public class ConfigurableProviderConverter implements ITypeConverter<ConfigurableProvider> {
+	@Override
+	public ConfigurableProvider convert(String value) throws Exception {
+		return ServiceProviders.getProviders().get(value);
 	}
 }

--- a/server/src/main/java/stonks/server/cli/converter/SocketAddressConverter.java
+++ b/server/src/main/java/stonks/server/cli/converter/SocketAddressConverter.java
@@ -19,20 +19,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.cli.converter;
 
-import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import picocli.CommandLine.ITypeConverter;
 
-import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
-
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
-
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
+public class SocketAddressConverter implements ITypeConverter<SocketAddress> {
+	@Override
+	public SocketAddress convert(String value) throws Exception {
+		var splits = value.split("\\:", 2);
+		switch (splits[0]) {
+		case "inet":
+			var splits2 = splits[1].split("\\:", 2);
+			return new InetSocketAddress(splits2[0], Integer.parseInt(splits2[1]));
+		case "socket":
+			return UnixDomainSocketAddress.of(splits[1]);
+		default:
+			throw new IllegalArgumentException("Unknown address: " + value);
+		}
 	}
 }

--- a/server/src/main/java/stonks/server/service/ConfigurableProvider.java
+++ b/server/src/main/java/stonks/server/service/ConfigurableProvider.java
@@ -19,20 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package stonks.server;
+package stonks.server.service;
 
-import java.io.IOException;
+import nahara.common.configurations.Config;
+import stonks.core.service.StonksService;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import picocli.CommandLine;
-import stonks.server.cli.MainCommand;
-
-public class Main {
-	public static final Logger LOGGER = LoggerFactory.getLogger("Main");
-
-	public static void main(String[] args) throws IOException {
-		System.exit(new CommandLine(new MainCommand()).execute(args));
-	}
+@FunctionalInterface
+public interface ConfigurableProvider {
+	public StonksService configure(Config config);
 }

--- a/server/src/main/java/stonks/server/service/ServiceProviders.java
+++ b/server/src/main/java/stonks/server/service/ServiceProviders.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 nahkd
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package stonks.server.service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import stonks.core.service.memory.MemoryCategory;
+import stonks.core.service.memory.MemoryProduct;
+import stonks.core.service.memory.StonksMemoryService;
+import stonks.server.Main;
+
+public class ServiceProviders {
+	private static final Map<String, ConfigurableProvider> PROVIDERS = new HashMap<>();
+
+	public static ConfigurableProvider add(String id, ConfigurableProvider provider) {
+		PROVIDERS.put(id, provider);
+		return provider;
+	}
+
+	public static Map<String, ConfigurableProvider> getProviders() { return Collections.unmodifiableMap(PROVIDERS); }
+
+	public static final ConfigurableProvider MEMORY = add("stonks:memory", config -> {
+		Main.LOGGER.warn("Memory service provider: You are using in-memory service, "
+			+ "which will lose all data when the server is stopped!");
+		var service = new StonksMemoryService();
+
+		for (var child : config.children("category").toList()) {
+			var categoryId = child.getValue();
+			if (categoryId.isEmpty()) {
+				Main.LOGGER.warn("Memory service provider: Category ID is missing");
+				continue;
+			}
+
+			var categoryName = child.firstChild("name")
+				.flatMap(v -> v.getValue())
+				.or(() -> categoryId)
+				.get();
+			var category = new MemoryCategory(categoryId.get(), categoryName);
+
+			for (var productConfig : child.children("product").toList()) {
+				var productId = productConfig.getValue();
+				if (productId.isEmpty()) {
+					Main.LOGGER.warn("Memory service provider: Product ID in " + categoryId.get() + " is missing");
+					continue;
+				}
+
+				var productName = productConfig.firstChild("name")
+					.flatMap(v -> v.getValue())
+					.orElse(productId.get());
+				var constructionData = productConfig.firstChild("construction")
+					.flatMap(v -> v.getValue())
+					.orElse("");
+				category.getModifiableMockProducts()
+					.add(new MemoryProduct(category, productId.get(), productName, constructionData));
+			}
+
+			service.getModifiableCategories().add(category);
+		}
+
+		return service;
+	});
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,5 +9,9 @@ plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
 }
 
+// The heart of Stonks
 include 'core'
+include 'server'
+
+// Frontend implementations
 include 'fabric'


### PR DESCRIPTION
Resolves #28 

This PR aims to add Stonks Server to sync market data between multiple game server instances.

## Tasks
- [x] Implement all service calls first
- [ ] Handle remote service disconnect (by returning failed task while reconnecting to service)

## Packets
The packet thing is pretty simple: 4 bytes for ``contentLength``, which is a signed integer (signed because this is Java), followed by a sequence of bytes with ``contentLength`` length.

Inside the content, we have the ID of the message type, which is 2 bytes for ``stringLength``, followed by a sequence of bytes. After that, we have the message content.

## Messages
Will be added to documentations.