### PR TITLE
Add note for ItemsAdapter

### DIFF
--- a/fabric/src/main/resources/default-config
+++ b/fabric/src/main/resources/default-config
@@ -61,6 +61,10 @@ useService stonks.fabric.service.IntegratedStonksService
             ]
 
 // Adapters
+// "stonks.fabric.adapter.provided.ItemsAdapter" is included so that Stonks can add/remove items in player's inventory
+// If you remove this adapter, Stonks will be unable to access player's inventory. If you don't need to have access to
+// player's inventory, you can remove this adapter.
+// Additionally, you can make your own adapter to hook with other mods, like trading RF power for example.
 useAdapter stonks.fabric.adapter.provided.ItemsAdapter
 
 // You need to include economy adapter by yourself.


### PR DESCRIPTION
Add a note telling user that `ItemsAdapter` is there so that Stonks can access player's inventory.

Related to #57 

---

Side note: I gotta admit, Stonks has been engineered to be this complicated. I feel it would be better to never have to configure the adapters like this, like letting Stonks automatically pick adapter when there is no adapters configured in configuration file.